### PR TITLE
Escape formatting character %

### DIFF
--- a/nohilight.pl
+++ b/nohilight.pl
@@ -18,6 +18,7 @@ sub remove_hilight {
 		foreach my $nick (@nicks) {
 			if ($stripped =~ /<.?$nick>/) {
 				my $window = $dest->{window};
+				$text =~ s/%/%%/g;
 				$window->print($text, MSGLEVEL_PUBLIC);
 				Irssi::signal_stop();
 			}


### PR DESCRIPTION
If % is in a message it gets interpreted as a formatting code, as per http://www.irssi.org/documentation/formats.