### PR TITLE
Display message only once

### DIFF
--- a/nohilight.pl
+++ b/nohilight.pl
@@ -21,6 +21,7 @@ sub remove_hilight {
 				$text =~ s/%/%%/g;
 				$window->print($text, MSGLEVEL_PUBLIC);
 				Irssi::signal_stop();
+				return;
 			}
 		}
 	}


### PR DESCRIPTION
This prevents the message from being displayed more than once if it matches more than one of the nicknames on our "no hilight" list. Otherwise it would print the message once for every nickname matched.

Relay bots are a prime example of how this bug can be triggered.