### PR TITLE
Use existing msglevels with hilight level removed

### DIFF
--- a/nohilight.pl
+++ b/nohilight.pl
@@ -19,7 +19,12 @@ sub remove_hilight {
 			if ($stripped =~ /<.?$nick>/) {
 				my $window = $dest->{window};
 				$text =~ s/%/%%/g;
-				$window->print($text, MSGLEVEL_PUBLIC);
+
+				# Remove hilight msglevel
+				$dest->{level} ^= MSGLEVEL_HILIGHT;
+				$dest->{level} |= MSGLEVEL_NOHILIGHT;
+
+				$window->print($text, $dest->{level});
 				Irssi::signal_stop();
 				return;
 			}

--- a/nohilight.pl
+++ b/nohilight.pl
@@ -18,6 +18,8 @@ sub remove_hilight {
 		foreach my $nick (@nicks) {
 			if ($stripped =~ /<.?$nick>/) {
 				my $window = $dest->{window};
+
+				# Escape formatting character %
 				$text =~ s/%/%%/g;
 
 				# Remove hilight msglevel


### PR DESCRIPTION
Instead of sending all messages as `MSGLEVEL_PUBLIC`, preserve the
original msglevel of the message and remove the hilight level.

I was in a situation where I both ignored a nick and added it to
`nohilight`:

	/ignore ignored_nick* NO_ACT
	/set nohilight_nicks ignored_nick

With `NO_ACT`, I expect messages from `ignored_nick` not to show
activity on the channel window. However, because all messages passing
through `nohilight` would be posted as `MSGLEVEL_PUBLIC`, the `NO_ACT`
level was ignored.

Also tacked on a comment to the `%` substitution line since I was
confused about what it was doing until I read the commit message.

Finally, it doesn't seem like this project is licensed, which makes me a
little wary of contributing, though I see there have been contributions
in the past. Would you consider adding a license?
https://choosealicense.com/no-license/